### PR TITLE
Remove trailing | that was breaking the script

### DIFF
--- a/clean_wordlist/clean_wordlist.sh
+++ b/clean_wordlist/clean_wordlist.sh
@@ -12,7 +12,7 @@ regexes=(
     "\/.*\/.*\/.*\/.*\/.*\/.*\/" # Ignore lines more than 6 directories deep (overly specific)
     "\w{8}-\w{4}-\w{4}-\w{4}-\w{12}" # Ignore UUIDs
     "[0-9]+[a-zA-Z]+[0-9]+[a-zA-Z]+[0-9]+" # Ignore multiple numbers and letters mixed together (likley noise)
-    "\.(png|jpg|jpeg|gif|svg|bmp|ttf|avif|wav|mp4|aac|ajax|css|all|)$" # Ignore low value filetypes
+    "\.(png|jpg|jpeg|gif|svg|bmp|ttf|avif|wav|mp4|aac|ajax|css|all)$" # Ignore low value filetypes
     "^$" # Ignores blank lines
 )
 


### PR DESCRIPTION
A trailing `|` was breaking the grep expression, rendering the whole grep and script void (at least in Mac OSX).

Before:
![before](https://user-images.githubusercontent.com/1380527/101151554-ba24fa80-3619-11eb-90b2-45f77e68095c.png)


After:
![after](https://user-images.githubusercontent.com/1380527/101151572-c315cc00-3619-11eb-9ed1-573e7eb7871c.png)
